### PR TITLE
upgrade yew and related dependencies, fix compiler errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ opt-level = "z"  # Optimize for size.
 # codegen-units = 1
 
 [dependencies]
-yew = "0.19.3"
-yew-router = "0.16"
+yew = { version = "0.20.0", features = ["csr"] }
+yew-router = "0.17.0"
 wasm-bindgen = "0.2.80"
 wasm-bindgen-futures = "0.4.30"
 wasm-logger = "0.2.0" # sets up logging from generated wasm files with stack traces in web console

--- a/src/components/body.rs
+++ b/src/components/body.rs
@@ -1,4 +1,4 @@
-use yew::{function_component, html, Children, Properties};
+use yew::{function_component, html, Children, Html, Properties};
 
 #[derive(Properties, PartialEq, Clone)]
 pub struct BodyProps {

--- a/src/components/cloudinary_image.rs
+++ b/src/components/cloudinary_image.rs
@@ -1,4 +1,4 @@
-use yew::{function_component, html, Properties};
+use yew::{function_component, html, Html, Properties};
 
 #[derive(Properties, PartialEq, Eq)]
 pub struct CloudinaryImageProps {

--- a/src/components/error_message.rs
+++ b/src/components/error_message.rs
@@ -1,4 +1,4 @@
-use yew::{classes, function_component, html, Children, Classes, Properties};
+use yew::{classes, function_component, html, Children, Classes, Html, Properties};
 
 #[derive(Properties, PartialEq)]
 pub struct ErrorMessageProps {

--- a/src/components/layout/footer.rs
+++ b/src/components/layout/footer.rs
@@ -1,5 +1,5 @@
 use chrono::{Datelike, Utc};
-use yew::{function_component, html};
+use yew::{function_component, html, Html};
 
 use crate::components::social_media_icons::SocialMediaIcons;
 

--- a/src/components/layout/header.rs
+++ b/src/components/layout/header.rs
@@ -1,4 +1,4 @@
-use yew::{function_component, html};
+use yew::{function_component, html, Html};
 
 use crate::components::Navigation;
 

--- a/src/components/layout/headings.rs
+++ b/src/components/layout/headings.rs
@@ -1,5 +1,5 @@
 use std::fmt::{Display, Formatter};
-use yew::{classes, function_component, html, Children, Classes, Properties};
+use yew::{classes, function_component, html, Children, Classes, Html, Properties};
 
 #[derive(PartialEq, Eq)]
 pub enum HeadingAlignment {

--- a/src/components/layout/page.rs
+++ b/src/components/layout/page.rs
@@ -1,4 +1,4 @@
-use yew::{classes, function_component, html, Children, Classes, Properties};
+use yew::{classes, function_component, html, Children, Classes, Html, Properties};
 
 #[derive(Properties, PartialEq)]
 pub struct PageProps {

--- a/src/components/layout/paragraph.rs
+++ b/src/components/layout/paragraph.rs
@@ -1,4 +1,4 @@
-use yew::{classes, function_component, html, Children, Classes, Properties};
+use yew::{classes, function_component, html, Children, Classes, Html, Properties};
 
 #[derive(Properties, PartialEq)]
 pub struct ParagraphProps {

--- a/src/components/mailto_link.rs
+++ b/src/components/mailto_link.rs
@@ -1,5 +1,5 @@
 use crate::components::InlineAnchor;
-use yew::{function_component, html, Properties};
+use yew::{function_component, html, Html, Properties};
 
 #[derive(Properties, PartialEq, Eq)]
 pub struct MailtoLinkProps {

--- a/src/components/success_message.rs
+++ b/src/components/success_message.rs
@@ -1,4 +1,4 @@
-use yew::{classes, function_component, html, Children, Classes, Properties};
+use yew::{classes, function_component, html, Children, Classes, Html, Properties};
 
 #[derive(Properties, PartialEq)]
 pub struct SuccessMessageProps {

--- a/src/components/util.rs
+++ b/src/components/util.rs
@@ -1,4 +1,4 @@
-use yew::{classes, function_component, html, Children, Properties};
+use yew::{classes, function_component, html, Children, Html, Properties};
 
 #[derive(Properties, PartialEq)]
 pub struct InlineAnchorProps {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use yew::prelude::*;
+use yew::Html;
 use yew_router::prelude::*;
 
 mod components;
@@ -22,7 +23,7 @@ enum Route {
     NotFound,
 }
 
-fn switch(routes: &Route) -> Html {
+fn switch(routes: Route) -> Html {
     match routes {
         Route::Home => html! { <Home /> },
         Route::Web => html! { <Web /> },
@@ -37,7 +38,7 @@ fn app() -> Html {
         <BrowserRouter>
             <Body>
                 <Header />
-                <Switch<Route> render={Switch::render(switch)} />
+                <Switch<Route> render={switch} />
                 <Footer />
             </Body>
         </BrowserRouter>
@@ -46,5 +47,5 @@ fn app() -> Html {
 
 fn main() {
     wasm_logger::init(wasm_logger::Config::default());
-    yew::start_app::<App>();
+    yew::Renderer::<App>::new().render();
 }

--- a/src/pages/contact.rs
+++ b/src/pages/contact.rs
@@ -1,6 +1,6 @@
 use lazy_static::lazy_static;
 
-use yew::{function_component, html};
+use yew::{function_component, html, Html};
 
 #[cfg(any(feature = "email-service", feature = "contact-form-mailto-link"))]
 use crate::components::ContactForm;

--- a/src/pages/home.rs
+++ b/src/pages/home.rs
@@ -1,4 +1,4 @@
-use yew::{function_component, html};
+use yew::{function_component, html, Html};
 
 use crate::components::{
     layout::{HeadingOne, Page, Paragraph},

--- a/src/pages/not_found.rs
+++ b/src/pages/not_found.rs
@@ -1,4 +1,4 @@
-use yew::{function_component, html};
+use yew::{function_component, html, Html};
 
 use crate::components::{Page, Paragraph};
 


### PR DESCRIPTION
Upgrading `yew` from `0.19.3` to `0.20.0` following the [migration guide](https://yew.rs/docs/migration-guides/yew/from-0_19_0-to-0_20_0).

