### PR TITLE
fix: best practice: set explicit width and height on img element inside cloudinary image component

### DIFF
--- a/src/components/CloudinaryImage/CloudinaryImage.tsx
+++ b/src/components/CloudinaryImage/CloudinaryImage.tsx
@@ -47,7 +47,15 @@ export default function CloudinaryImage({
     [width],
   );
 
-  const imgElement = <img src={img.toURL()} alt={alt} style={style} />;
+  const imgElement = (
+    <img
+      src={img.toURL()}
+      alt={alt}
+      style={style}
+      width={width}
+      height={height}
+    />
+  );
 
   if (showCaption) {
     return (


### PR DESCRIPTION
- set explicit width and height on img element inside cloudinary image component to address a lighthouse warning
