### PR TITLE
chore: add Playwright MCP and backup files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,9 @@ yarn-error.log*
 # cypress test artifacts
 tests/integration/screenshots
 tests/integration/videos
+
+# playwright mcp artifacts
+.playwright-mcp/
+
+# backup files
+*.backup


### PR DESCRIPTION
## Summary

Add `.playwright-mcp/` directory and `*.backup` files to `.gitignore` to prevent accidentally committing debugging artifacts and temporary backup files.

## What Changed

### .gitignore
Added two new ignore patterns:
- `.playwright-mcp/` - Playwright MCP screenshots and debugging artifacts
- `*.backup` - Backup files (e.g., `postcss.config.js.backup`)

## Why This Change

### Playwright MCP Directory
- Created during debugging sessions when using Playwright MCP browser automation
- Contains screenshots and temporary artifacts
- Not needed in version control
- Specific to local development/debugging workflow

### Backup Files Pattern
- Prevents accidental commits of `.backup` files
- Common pattern when backing up configuration files before modifications
- Example: `postcss.config.js.backup` currently in working directory

## Impact

- Cleaner `git status` output (no untracked artifacts)
- Prevents accidental commits of debugging/temporary files
- Aligns with project's existing gitignore patterns (Cypress screenshots/videos)

## Test Plan

- [x] Verify `.gitignore` syntax is valid
- [x] Confirm `.playwright-mcp/` and `postcss.config.js.backup` no longer appear in `git status`
- [x] No impact on existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)