### PR TITLE
fix(feature-flags): add localhost:4173 to CORS allowed origins

### DIFF
--- a/packages/feature-flags/wrangler.toml
+++ b/packages/feature-flags/wrangler.toml
@@ -8,4 +8,4 @@ id = "39adbb9db8fb437db45d5bd0bc285f4f"
 preview_id = "2321e67477194ac696eb2c708e248d1e"
 
 [vars]
-ALLOWED_ORIGINS = "https://tylerearls.com,http://localhost:5173,http://localhost:3000"
+ALLOWED_ORIGINS = "https://tylerearls.com,http://localhost:5173,http://localhost:3000,http://localhost:4173"


### PR DESCRIPTION
## Summary
- Add Vite preview server port (4173) to the feature flags Worker's allowed origins
- Enables local testing of production builds with `npm run preview`

## Test plan
- [x] Verified feature flags load correctly on `http://localhost:4173`
- [x] Worker deployed and tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)