### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/taearls/portfolio/security/code-scanning/4](https://github.com/taearls/portfolio/security/code-scanning/4)

In general, the fix is to explicitly add a `permissions:` block to the workflow to restrict the `GITHUB_TOKEN` to the least privileges needed. Since these jobs only check out and read the repository code and upload artifacts, read-only access to repository contents is sufficient.

The single best fix here is to add a workflow-level `permissions:` block immediately after the `name: CI` line (or after `on:`), setting `contents: read`. This will apply to all jobs (`lint`, `test`, `build`) because none of them currently define their own `permissions` blocks. No steps in the provided snippet require write access to contents, issues, or pull requests, and artifact upload does not need repo write permissions. No additional imports or methods are required since this is a YAML configuration change only.

Concretely, in `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

near the top-level of the workflow. All other lines remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
