### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/toggle-feature-flag.yml
+++ b/.github/workflows/toggle-feature-flag.yml
@@ -19,6 +19,8 @@ on:
         required: false
         type: string
 
+permissions: {}
+
 jobs:
   toggle-flag:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/taearls/portfolio/security/code-scanning/2](https://github.com/taearls/portfolio/security/code-scanning/2)

In general, fix this by explicitly adding a `permissions` block to the workflow (or the specific job) to restrict the `GITHUB_TOKEN` to the minimal required scopes. When a job does not interact with the GitHub API or repository contents at all, you can safely set `permissions: {}` (or `permissions: read-all` if some read access is needed).

For this specific workflow, the `toggle-flag` job does not interact with repository contents, issues, pull requests, or environments beyond selecting one to run in. All operations are local shell commands and an outbound `curl` to an external API authenticated via secrets. The safest, least-privilege change is to define `permissions: {}` at the workflow root so it applies to all jobs. Concretely, in `.github/workflows/toggle-feature-flag.yml`, insert:

```yaml
permissions: {}
```

between the `on:` block and the `jobs:` block (after line 21 and before line 22). No additional imports, methods, or other definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
