### PR TITLE
fix(nav): resolve NavigationToggle visibility CSS specificity conflict

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -519,6 +519,80 @@ _None - All prerequisites for #43 are complete. Ready to implement._
 
 ## Changelog
 
+### 2025-12-23 - Issue #97 Completed: NavigationToggle Visibility Fix
+
+- **Completed**: #97 - NavigationToggle does not show/hide navigation bar
+- **Priority**: 🔴 BUG (Navigation toggle button animated but navigation never hid)
+- **Status**: Completed Dec 23, 2025
+- **Effort**: ~1 hour (including comprehensive test suite)
+- **Impact**: Fixed critical navigation UX bug on mobile viewports
+
+**Root Cause Analysis**:
+
+CSS specificity conflict in `NavigationBar.tsx`. The CSS Module class `navigation-list-container` defined `display: inline-flex` with higher specificity than Tailwind's `hidden` utility (`display: none`). The navigation remained visible even when state was `CLOSED`.
+
+**Implementation Details**:
+
+1. **Added CSS Module `.closed` class** (`NavigationBar.module.css:39-41`)
+   - Created `.navigation-list-container.closed` rule with `display: none`
+   - Uses CSS Module specificity to properly override `inline-flex`
+   - Added comment documenting the specificity requirement
+
+2. **Updated NavigationBar component** (`NavigationBar.tsx:89-92`)
+   - Changed from Tailwind's `"hidden"` to CSS Module's `styles.closed`
+   - Maintains consistent specificity within CSS Module scope
+
+3. **Added comprehensive test suite** (`tests/component/NavigationBar.spec.tsx`)
+   - 8 test cases covering toggle functionality
+   - Tests CSS Module class application (`_closed_` pattern matching)
+   - Verifies aria-label accessibility updates
+   - State-agnostic tests that work regardless of initial viewport state
+
+**Changes**:
+
+```css
+/* NavigationBar.module.css - Added */
+.navigation-list-container.closed {
+  display: none;
+}
+```
+
+```tsx
+// NavigationBar.tsx - Before
+className={mergeClasses(
+  styles["navigation-list-container"],
+  isNavigationOpen.value === NAVIGATION_STATE.CLOSED && "hidden",
+)}
+
+// NavigationBar.tsx - After
+className={mergeClasses(
+  styles["navigation-list-container"],
+  isNavigationOpen.value === NAVIGATION_STATE.CLOSED && styles.closed,
+)}
+```
+
+**Files Modified**:
+
+- `src/components/navigation/NavigationBar/NavigationBar.module.css` - Added `.closed` class
+- `src/components/navigation/NavigationBar/NavigationBar.tsx` - Use CSS Module class
+
+**Files Created**:
+
+- `tests/component/NavigationBar.spec.tsx` - Comprehensive test suite (8 tests)
+
+**Testing**:
+
+- ✅ All 190 unit tests passing (8 new NavigationBar tests)
+- ✅ Production build successful
+- ✅ Navigation toggle now properly shows/hides navigation list
+- ✅ CSS Module class verified with pattern matching
+
+**Technical Lesson**:
+
+When using CSS Modules with Tailwind, be aware of specificity conflicts. CSS Module classes have higher specificity than Tailwind utilities. Use CSS Module classes for state-based visibility changes when the base styles are defined in CSS Modules.
+
+---
+
 ### 2025-12-23 - Issue #65 Completed: Font Size Readability Enhancement
 
 - **Completed**: #65 - Increase Font Size for Desktop/Tablet Readability

--- a/src/components/navigation/NavigationBar/NavigationBar.module.css
+++ b/src/components/navigation/NavigationBar/NavigationBar.module.css
@@ -35,6 +35,11 @@
   @apply sm:h-[76px] sm:w-full sm:flex-row;
 }
 
+/* Hide navigation when closed on mobile - uses CSS Module specificity to override inline-flex */
+.navigation-list-container.closed {
+  display: none;
+}
+
 /* WCAG 2.5.5 - Ensure navigation links meet 44×44px minimum touch target */
 .navigation-list-container a {
   min-height: var(--touch-target-min);

--- a/src/components/navigation/NavigationBar/NavigationBar.tsx
+++ b/src/components/navigation/NavigationBar/NavigationBar.tsx
@@ -88,7 +88,7 @@ export default function NavigationBar({ links }: NavigationBarProps) {
         role="menu"
         className={mergeClasses(
           styles["navigation-list-container"],
-          isNavigationOpen.value === NAVIGATION_STATE.CLOSED && "hidden",
+          isNavigationOpen.value === NAVIGATION_STATE.CLOSED && styles.closed,
         )}
       >
         <FlexContainer

--- a/tests/component/NavigationBar.spec.tsx
+++ b/tests/component/NavigationBar.spec.tsx
@@ -1,0 +1,245 @@
+import "@testing-library/jest-dom/vitest";
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+
+import NavigationBar from "@/components/navigation/NavigationBar/NavigationBar.tsx";
+import ThemeContext from "@/state/contexts/ThemeContext.tsx";
+import type { RouteDataItem } from "@/constants/navigationData.tsx";
+
+// Mock navigation links for testing
+const mockLinks: Array<RouteDataItem> = [
+  {
+    ariaLabel: "Visit Home Page",
+    href: "/",
+    name: "Home",
+  },
+  {
+    ariaLabel: "Visit Code Page",
+    href: "/code",
+    name: "Code",
+  },
+  {
+    ariaLabel: "Visit Contact Page",
+    href: "/contact",
+    name: "Contact",
+  },
+];
+
+const renderNavigationBar = () => {
+  return render(
+    <MemoryRouter>
+      <ThemeContext.Provider>
+        <NavigationBar links={mockLinks} />
+      </ThemeContext.Provider>
+    </MemoryRouter>,
+  );
+};
+
+describe("<NavigationBar />", () => {
+  describe("Navigation Toggle Functionality", () => {
+    it("should toggle navigation visibility when toggle button is clicked", () => {
+      renderNavigationBar();
+
+      const navigationList = screen.getByRole("menu");
+
+      // Get the initial state of the toggle button
+      // The button aria-label tells us the current action (Open = nav is closed, Close = nav is open)
+      const initialButton =
+        screen.queryByRole("button", { name: /Open Navigation/i }) ||
+        screen.queryByRole("button", { name: /Close Navigation/i });
+
+      expect(initialButton).toBeInTheDocument();
+
+      const isInitiallyOpen = initialButton?.getAttribute("aria-label") === "Close Navigation";
+
+      if (isInitiallyOpen) {
+        // Navigation starts open - verify no closed class
+        expect(navigationList.className).not.toMatch(/closed/);
+
+        // Click to close
+        fireEvent.click(initialButton!);
+
+        // Should now have closed class
+        expect(navigationList.className).toMatch(/closed/);
+
+        // Button should now say "Open Navigation"
+        expect(
+          screen.getByRole("button", { name: /Open Navigation/i }),
+        ).toBeInTheDocument();
+
+        // Click to open again
+        fireEvent.click(
+          screen.getByRole("button", { name: /Open Navigation/i }),
+        );
+
+        // Should no longer have closed class
+        expect(navigationList.className).not.toMatch(/closed/);
+      } else {
+        // Navigation starts closed - verify has closed class
+        expect(navigationList.className).toMatch(/closed/);
+
+        // Click to open
+        fireEvent.click(initialButton!);
+
+        // Should no longer have closed class
+        expect(navigationList.className).not.toMatch(/closed/);
+
+        // Button should now say "Close Navigation"
+        expect(
+          screen.getByRole("button", { name: /Close Navigation/i }),
+        ).toBeInTheDocument();
+
+        // Click to close again
+        fireEvent.click(
+          screen.getByRole("button", { name: /Close Navigation/i }),
+        );
+
+        // Should have closed class again
+        expect(navigationList.className).toMatch(/closed/);
+      }
+    });
+
+    it("should apply closed CSS class when navigation is closed", () => {
+      renderNavigationBar();
+
+      const navigationList = screen.getByRole("menu");
+
+      // Find the toggle button and get current state
+      const closeButton = screen.queryByRole("button", {
+        name: /Close Navigation/i,
+      });
+
+      if (closeButton) {
+        // If we have a close button, navigation is open - click to close
+        fireEvent.click(closeButton);
+      }
+
+      // Now navigation should be closed
+      // The closed class from CSS Module should be applied
+      // CSS Module mangles the class name, so we check for pattern containing "closed"
+      expect(navigationList.className).toMatch(/closed/);
+    });
+
+    it("should remove closed CSS class when navigation is opened", () => {
+      renderNavigationBar();
+
+      const navigationList = screen.getByRole("menu");
+
+      // First ensure navigation is closed
+      const closeButton = screen.queryByRole("button", {
+        name: /Close Navigation/i,
+      });
+
+      if (closeButton) {
+        fireEvent.click(closeButton);
+      }
+
+      // Verify it's closed
+      expect(navigationList.className).toMatch(/closed/);
+
+      // Now open it
+      const openButton = screen.getByRole("button", {
+        name: /Open Navigation/i,
+      });
+      fireEvent.click(openButton);
+
+      // The closed class should be removed
+      expect(navigationList.className).not.toMatch(/closed/);
+    });
+
+    it("should toggle between open and closed states on multiple clicks", () => {
+      renderNavigationBar();
+
+      const navigationList = screen.getByRole("menu");
+
+      // Perform multiple toggles and verify state changes correctly each time
+      for (let i = 0; i < 4; i++) {
+        const currentButton =
+          screen.queryByRole("button", { name: /Open Navigation/i }) ||
+          screen.queryByRole("button", { name: /Close Navigation/i });
+
+        expect(currentButton).toBeInTheDocument();
+
+        const wasOpen =
+          currentButton?.getAttribute("aria-label") === "Close Navigation";
+
+        fireEvent.click(currentButton!);
+
+        // State should have toggled
+        if (wasOpen) {
+          expect(navigationList.className).toMatch(/closed/);
+        } else {
+          expect(navigationList.className).not.toMatch(/closed/);
+        }
+      }
+    });
+
+    it("should render all visible navigation links", () => {
+      renderNavigationBar();
+
+      // Check that all non-hidden links are rendered
+      expect(screen.getByText("Home")).toBeInTheDocument();
+      expect(screen.getByText("Code")).toBeInTheDocument();
+      expect(screen.getByText("Contact")).toBeInTheDocument();
+    });
+
+    it("should have accessible toggle button with aria-label", () => {
+      renderNavigationBar();
+
+      // Should have a toggle button with appropriate aria-label
+      const toggleButton =
+        screen.queryByRole("button", { name: /Open Navigation/i }) ||
+        screen.queryByRole("button", { name: /Close Navigation/i });
+
+      expect(toggleButton).toBeInTheDocument();
+      expect(toggleButton).toHaveAttribute("aria-label");
+    });
+
+    it("should update aria-label when toggle state changes", () => {
+      renderNavigationBar();
+
+      // Get initial button
+      const initialButton =
+        screen.queryByRole("button", { name: /Open Navigation/i }) ||
+        screen.queryByRole("button", { name: /Close Navigation/i });
+
+      const initialLabel = initialButton?.getAttribute("aria-label");
+
+      // Click to toggle
+      fireEvent.click(initialButton!);
+
+      // Get new button
+      const newButton =
+        screen.queryByRole("button", { name: /Open Navigation/i }) ||
+        screen.queryByRole("button", { name: /Close Navigation/i });
+
+      const newLabel = newButton?.getAttribute("aria-label");
+
+      // Labels should be different after toggle
+      expect(newLabel).not.toBe(initialLabel);
+    });
+  });
+
+  describe("CSS Module Integration", () => {
+    it("should use CSS Module closed class for hiding navigation (not Tailwind hidden)", () => {
+      renderNavigationBar();
+
+      const navigationList = screen.getByRole("menu");
+
+      // Ensure navigation is closed
+      const closeButton = screen.queryByRole("button", {
+        name: /Close Navigation/i,
+      });
+      if (closeButton) {
+        fireEvent.click(closeButton);
+      }
+
+      // The class should contain "closed" (CSS Module pattern)
+      // It should NOT just be "hidden" (Tailwind utility - which has specificity issues)
+      expect(navigationList.className).toMatch(/closed/);
+      // Verify it's a CSS Module class (contains hash suffix like _closed_abc123)
+      expect(navigationList.className).toMatch(/_closed_[a-z0-9]+/i);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes CSS specificity conflict where CSS Module `display: inline-flex` overrode Tailwind's `hidden` utility
- Navigation toggle button now properly shows/hides navigation list on mobile viewports
- Adds comprehensive test suite to prevent regression

## Changes

### Root Cause
The CSS Module class `navigation-list-container` defined `display: inline-flex` with higher specificity than Tailwind's `hidden` utility (`display: none`). The navigation remained visible even when state was `CLOSED`.

### Fix
- Added `.closed` class to `NavigationBar.module.css` that properly overrides `inline-flex`
- Updated `NavigationBar.tsx` to use `styles.closed` instead of Tailwind's `"hidden"`
- Maintains consistent CSS specificity within CSS Module scope

### Testing
- Added 8 comprehensive tests for NavigationBar toggle functionality
- Tests verify CSS Module class application with pattern matching
- Tests are state-agnostic (work regardless of initial viewport)

## Test plan

- [x] All 190 unit tests passing
- [x] Production build successful
- [x] Navigation toggle properly shows/hides navigation on mobile
- [x] CSS Module `.closed` class verified with pattern matching

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)