### PR TITLE
fix(nav): vertically center navigation toggle in navigation bar

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## Executive Summary
 
-This roadmap outlines the development plan for Tyler Earls' portfolio website, focusing on performance optimization, modern React tooling, and enhanced user experience. The project has **completed Phase 5 (React Compiler Integration)**, **Phase 6 (CI/CD setup)**, **Phase 7 (Accessibility & Core Web Vitals)**, and **Phase 8 (GitOps Feature Flags)**, with **5 open low-priority issues** remaining.
+This roadmap outlines the development plan for Tyler Earls' portfolio website, focusing on performance optimization, modern React tooling, and enhanced user experience. The project has **completed Phase 5 (React Compiler Integration)**, **Phase 6 (CI/CD setup)**, **Phase 7 (Accessibility & Core Web Vitals)**, and **Phase 8 (GitOps Feature Flags)**, with **4 open low-priority issues** remaining.
 
 **Current Focus**: All critical, high, and medium priority work complete! Only low-priority enhancements and research spikes remain. The portfolio is production-ready with comprehensive accessibility compliance, feature flag infrastructure, and CI/CD automation.
 
@@ -21,7 +21,7 @@ This roadmap outlines the development plan for Tyler Earls' portfolio website, f
 
 ## Open Issues Summary
 
-### Priority Breakdown (5 Open Issues)
+### Priority Breakdown (4 Open Issues)
 
 #### 🔴 Critical Priority (0 issues)
 
@@ -53,7 +53,7 @@ _All medium-priority issues resolved!_
 
 ✅ **#14** - Add Working Email Contact Form - **COMPLETED Dec 7, 2025**
 
-#### 🔵 Low Priority (4 issues) - Effort: ~2 weeks total
+#### 🔵 Low Priority (3 issues) - Effort: ~1-2 weeks total
 
 - **#33** - Spike: Integrate PRs with Graphite - _~1-2 hours_
   - Labels: `type: spike`, `area: ci/cd`, `priority: low`, `effort: small`
@@ -62,9 +62,10 @@ _All medium-priority issues resolved!_
 - **#64** - Improve Color Contrast for WCAG AAA Compliance - _~2-4 hours_
   - Title: 🔵 MINOR
   - Note: WCAG AA already met, AAA is enhancement
-- **#103** - Improve mobile UX for Code page tabs - _~3-4 hours_
-  - Labels: `enhancement`, `accessibility`, `mobile`, `ux`
-  - Segmented control pattern for mobile, sticky tabs, touch feedback
+
+✅ **#105** - Vertically center navigation toggle button - **COMPLETED Dec 27, 2025**
+
+✅ **#103** - Improve mobile UX for Code page tabs - **COMPLETED Dec 27, 2025**
 
 ✅ **#10** - Add Resume Page - **COMPLETED Dec 24, 2025**
 
@@ -517,6 +518,34 @@ _None - All prerequisites for #43 are complete. Ready to implement._
 ---
 
 ## Changelog
+
+### 2025-12-27 - Issue #105 Completed: Vertically Center Navigation Toggle
+
+- **Completed**: #105 - Vertically center navigation toggle button in navigation bar
+- **Priority**: 🔵 LOW (Bug fix)
+- **Status**: Completed Dec 27, 2025
+- **Effort**: ~15 minutes
+- **Impact**: Navigation toggle is now properly vertically centered in the 64px navigation bar
+
+**Problem:**
+- Navigation toggle was positioned 16px from top (`top: 0` + `margin: 1rem`)
+- With 64px nav bar height and 44px toggle, this left only 4px below
+- Toggle appeared top-aligned rather than vertically centered
+
+**Solution:**
+- Changed positioning to use `top: 50%` with `transform: translateY(-50%)`
+- Updated margin to `0 1rem` (horizontal only)
+- Toggle is now mathematically centered (10px from top and bottom)
+
+**Files Modified:**
+- `src/components/navigation/NavigationBar/NavigationBar.module.css`
+
+**Testing:**
+- ✅ All 241 unit tests passing
+- ✅ Production build successful
+- ✅ Visual verification on mobile and desktop
+
+---
 
 ### 2025-12-27 - Issue #103 Completed: Mobile Tabs UX Enhancement
 
@@ -1776,6 +1805,6 @@ All high-priority accessibility issues (#61, #62, #63) have been resolved. Mediu
 
 ---
 
-**Last Updated**: December 27, 2025 (All Priority Work Complete - 4 Low-Priority Issues Remaining)
+**Last Updated**: December 27, 2025 (All Priority Work Complete - 3 Low-Priority Issues Remaining)
 **Maintained By**: Tyler Earls
 **Generated With**: Claude Code

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -528,19 +528,23 @@ _None - All prerequisites for #43 are complete. Ready to implement._
 - **Impact**: Navigation toggle is now properly vertically centered in the 64px navigation bar
 
 **Problem:**
+
 - Navigation toggle was positioned 16px from top (`top: 0` + `margin: 1rem`)
 - With 64px nav bar height and 44px toggle, this left only 4px below
 - Toggle appeared top-aligned rather than vertically centered
 
 **Solution:**
+
 - Changed positioning to use `top: 50%` with `transform: translateY(-50%)`
 - Updated margin to `0 1rem` (horizontal only)
 - Toggle is now mathematically centered (10px from top and bottom)
 
 **Files Modified:**
+
 - `src/components/navigation/NavigationBar/NavigationBar.module.css`
 
 **Testing:**
+
 - ✅ All 241 unit tests passing
 - ✅ Production build successful
 - ✅ Visual verification on mobile and desktop

--- a/src/components/navigation/NavigationBar/NavigationBar.module.css
+++ b/src/components/navigation/NavigationBar/NavigationBar.module.css
@@ -51,13 +51,13 @@
 
 .navigation-toggle-container {
   position: absolute;
-  top: 0;
+  top: 50%;
+  transform: translateY(-50%);
   right: 0.25rem;
   grid-area: toggle;
   display: inline-flex;
-  align-self: flex-start;
   align-items: center;
   column-gap: 1rem;
   width: fit-content;
-  margin: 1rem;
+  margin: 0 1rem;
 }


### PR DESCRIPTION
## Summary

- Fix navigation toggle vertical alignment in the navigation bar
- Toggle was positioned 16px from top, 4px from bottom (not centered)
- Now properly centered using CSS transform technique
- Update ROADMAP.md marking issue #105 as completed

## Problem

The navigation toggle button (hamburger menu) was not vertically centered in the 64px navigation bar:
- Previous: `top: 0` + `margin: 1rem` = 16px from top
- With 44px toggle height, only 4px remained below
- Toggle appeared top-aligned rather than centered

## Solution

Changed CSS positioning in `NavigationBar.module.css`:
```css
.navigation-toggle-container {
  top: 50%;
  transform: translateY(-50%);
  margin: 0 1rem;  /* horizontal only */
}
```

This centers the toggle mathematically: (64px - 44px) / 2 = 10px from top and bottom.

## Test plan

- [x] ESLint passes
- [x] Prettier format check passes
- [x] All 241 unit tests pass
- [x] Production build successful
- [x] Visual verification on mobile (375px) - closed state
- [x] Visual verification on mobile - open state
- [x] Visual verification on desktop (1280px)
- [x] Toggle remains properly positioned during open/close transitions

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)