### PR TITLE
fix(fonts): use relative paths in @font-face declarations for production

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
       /* Ubuntu metrics adjusted to match Arial fallback to prevent layout shift */
       @font-face {
         font-family: "Ubuntu";
-        src: url("/fonts/ubuntu-regular.woff2") format("woff2");
+        src: url("./fonts/ubuntu-regular.woff2") format("woff2");
         font-weight: 400;
         font-style: normal;
         font-display: swap;
@@ -22,7 +22,7 @@
 
       @font-face {
         font-family: "Ubuntu";
-        src: url("/fonts/ubuntu-bold.woff2") format("woff2");
+        src: url("./fonts/ubuntu-bold.woff2") format("woff2");
         font-weight: 700;
         font-style: normal;
         font-display: swap;
@@ -35,7 +35,7 @@
       /* Limelight metrics adjusted to match serif fallback */
       @font-face {
         font-family: "Limelight";
-        src: url("/fonts/limelight-regular.woff2") format("woff2");
+        src: url("./fonts/limelight-regular.woff2") format("woff2");
         font-weight: 400;
         font-style: normal;
         font-display: swap;


### PR DESCRIPTION
Changes:
- Updated font paths from /fonts/ to ./fonts/ in @font-face declarations
- Ensures fonts load correctly in production build (Cloudflare Pages)
- Paths now match the preload link paths for consistency

Issue: Vite's base config was transforming preload link paths to ./fonts/
but leaving @font-face url() paths as fonts/, causing fonts to fail loading
in production while working fine in development.

This fix ensures all font references use consistent relative paths.