### PR TITLE
chore: increase Claude max-turns from 15 to 30

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -47,5 +47,5 @@ jobs:
           # Configure Claude's behavior
           claude_args: |
             --model claude-sonnet-4-5-20250929
-            --max-turns 15
+            --max-turns 30
             --system-prompt "You are assisting with Tyler Earls' portfolio website. Follow the coding standards in CLAUDE.md. Ensure all changes are tested and documented."


### PR DESCRIPTION
## Summary
Increases the `--max-turns` setting for the Claude Code GitHub Action from 15 to 30, allowing for longer interactions when needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)