### PR TITLE
feat: enable npm and git commands for Claude Code action

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -48,4 +48,5 @@ jobs:
           claude_args: |
             --model claude-sonnet-4-5-20250929
             --max-turns 30
+            --allowedTools "Bash(npm:*),Bash(git status),Bash(git diff),Bash(git log)"
             --system-prompt "You are assisting with Tyler Earls' portfolio website. Follow the coding standards in CLAUDE.md. Ensure all changes are tested and documented."


### PR DESCRIPTION
## Summary
Adds `--allowedTools` configuration to the Claude Code GitHub Action, enabling Claude to run verification commands.

## Changes
Added to `claude_args`:
```yaml
--allowedTools "Bash(npm:*),Bash(git status),Bash(git diff),Bash(git log)"
```

## What This Enables
- **`Bash(npm:*)`** - All npm commands (install, test, build, lint, format, etc.)
- **`Bash(git status)`** - Check repository status
- **`Bash(git diff)`** - View changes
- **`Bash(git log)`** - View commit history

## Security
- Uses `Bash(npm:*)` instead of unrestricted `Bash(*)` to limit scope
- Git commands are read-only (no destructive operations like force push)
- All changes still require manual PR review

🤖 Generated with [Claude Code](https://claude.com/claude-code)