### PR TITLE
docs: add archive notice with link to websites-monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+> **⚠️ This repository has been archived.** Development has moved to the [websites-monorepo](https://github.com/taearls/websites-monorepo). The portfolio app lives at [`apps/portfolio/`](https://github.com/taearls/websites-monorepo/tree/main/apps/portfolio) in the monorepo.
+
+---
+
 # About Me
 
 I'm a fullstack developer and musician based in Chicago, IL. Outside of tech, I'm also a [musician](https://www.cuckooandthebirds.com) and an avid fan of Star Trek.


### PR DESCRIPTION
## Summary

- Adds an archive notice at the top of README.md directing users to the [websites-monorepo](https://github.com/taearls/websites-monorepo)
- Links directly to [`apps/portfolio/`](https://github.com/taearls/websites-monorepo/tree/main/apps/portfolio) in the monorepo

This is part of [taearls/websites-monorepo#12](https://github.com/taearls/websites-monorepo/issues/12) — archiving the original repositories after migrating to the monorepo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added repository archiving notice at the top of README with reference to the monorepo
  * Introduced visual separators for improved document organization
  * Fixed list formatting in "Previous Iterations" section for consistent numbering standards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->