### PR TITLE
fix(security): bump qs override to 6.14.2 (CVE-2026-2391)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10830,9 +10830,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "xstate": "^5.23.0"
   },
   "overrides": {
-    "qs": "6.14.1"
+    "qs": "6.14.2"
   },
   "devDependencies": {
     "@dreamsicle.io/stylelint-config-tailwindcss": "^1.1.2",


### PR DESCRIPTION
## Summary

Resolves [Dependabot alert #38](https://github.com/taearls/portfolio/security/dependabot/38) (`GHSA-w7fw-mjwx-w883` / `CVE-2026-2391`) — `qs`'s `arrayLimit` bypass in comma parsing allows DoS via memory exhaustion.

- Bump the `qs` override in `package.json` from `6.14.1` → `6.14.2`
- Regenerate `package-lock.json` so the transitive `qs` (consumed by `@cypress/request` via `cypress`) resolves to the patched version

## Why Dependabot couldn't auto-generate this PR

The repo had an existing `"overrides": { "qs": "6.14.1" }` entry from a prior security patch (#146). Because `qs` is a *transitive* dev dependency and the override pins an *exact* version, Dependabot's lockfile-only update strategy can't bump it — modifying the override requires a `package.json` edit, which Dependabot's security-update flow declines to make for transitive deps under an exact-version override. That's why no PR was opened despite the alert being open.

## Scope

- Dev-only impact: `qs` is reached only via `cypress` → `@cypress/request`, used in integration tests. No production runtime exposure.
- Severity: low (CVSS 3.7) — exploitable only when consumer code sets `comma: true` with a large untrusted input. Cypress doesn't expose this surface in our tests, so this is hygiene more than active risk.

## Validation

- [x] `npm install` — lockfile regenerated, `npm ls qs` confirms `qs@6.14.2 overridden`
- [x] `npm run lint:check` — clean
- [x] `npm run build` — succeeds (tsc + vite)
- [x] `npm run test` — 300/300 unit tests pass
- [ ] CI to verify integration tests on the runner

## Test plan

- [ ] Confirm CI green (lint, format, unit, integration, build)
- [ ] Verify Dependabot alert #38 auto-closes on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a utility package dependency to a newer patch version for improved stability and compatibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/taearls/portfolio/pull/190)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->