### PR TITLE
fix(test): migrate feature-flags worker vitest config to pool-workers v4

### DIFF
--- a/workers/feature-flags/package-lock.json
+++ b/workers/feature-flags/package-lock.json
@@ -11,7 +11,7 @@
         "@cloudflare/vitest-pool-workers": "^0.16.3",
         "@cloudflare/workers-types": "^4.20241127.0",
         "typescript": "^5.7.2",
-        "vitest": "^4.0.16",
+        "vitest": "^4.1.0",
         "wrangler": "^4.90.0"
       }
     },

--- a/workers/feature-flags/test/index.test.ts
+++ b/workers/feature-flags/test/index.test.ts
@@ -37,8 +37,11 @@ const mockKVNamespace = {
 };
 
 describe("Feature Flags Worker", () => {
-  beforeEach(() => {
-    // Reset any mocks if needed
+  beforeEach(async () => {
+    // handleGetFlags caches GET /api/flags responses in caches.default keyed
+    // by request URL. The Workers test pool does not reset the Cache API
+    // between tests, so clear the cached entry to keep tests isolated.
+    await caches.default.delete("http://localhost/api/flags");
   });
 
   describe("GET /api/flags", () => {

--- a/workers/feature-flags/vitest.config.ts
+++ b/workers/feature-flags/vitest.config.ts
@@ -1,11 +1,15 @@
-import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
+import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+import { defineConfig } from "vitest/config";
 
-export default defineWorkersConfig({
-  test: {
-    poolOptions: {
-      workers: {
-        wrangler: { configPath: "./wrangler.toml" },
-      },
-    },
-  },
+export default defineConfig({
+  plugins: [
+    cloudflareTest({
+      wrangler: { configPath: "./wrangler.toml" },
+      // Tests inject a mocked KV binding and run against local Miniflare
+      // storage, so skip the authenticated remote proxy that the
+      // `remote = true` KV namespace in wrangler.toml would otherwise require.
+      remoteBindings: false,
+    }),
+  ],
+  test: {},
 });


### PR DESCRIPTION
The worker's vitest suite could not run: vitest.config.ts imported
defineWorkersConfig from "@cloudflare/vitest-pool-workers/config", but the
0.16.x line (vitest 4 support) removed that subpath export, causing
`Missing "./config" specifier` and failing the whole suite.

Migrate to the v4 API (per the package's vitest-v3-to-v4 codemod):
- import cloudflareTest from "@cloudflare/vitest-pool-workers"
- use defineConfig from "vitest/config"
- pass the workers options as a cloudflareTest() plugin instead of
  test.poolOptions.workers

Also set remoteBindings: false so the pool uses local Miniflare storage
instead of trying to open an authenticated remote proxy for the KV
namespace that wrangler.toml marks `remote = true` (tests inject a mocked
KV binding, so no remote access is needed).

Finally, clear caches.default in beforeEach: the v4 pool does not reset the
Cache API between tests, so handleGetFlags' cached /api/flags response
leaked across tests. All 15 tests now pass and tsc build is clean.